### PR TITLE
Add support to {match} replacement in message and "both" type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,11 @@ jobs:
               "type": "body",
               "regex": ".*Test: \\?.*",
               "message": "The requested information was not filled out."
+            },
+            {
+              "type": "both",
+              "regex":".*(mangago|mangafox|hq\s*dragon|manga\s*host).*",
+              "caseIgnore": true,
+              "message": "{match} will not be added back as it is too difficult to maintain"
             }
           ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v1
       with:
-        ref: 'add-blocklist-rule'
+        ref: add-blocklist-rule
 
     - name: Autoclose issue
       # uses: arkon/issue-closer-action@v3.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Autoclose issue
-      # uses: arkon/issue-closer-action@v3.3
+      # uses: arkon/issue-closer-action@v3.2
       uses: ./
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,9 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v1
-      with:
-        ref: add-blocklist-rule
 
     - name: Autoclose issue
-      # uses: arkon/issue-closer-action@v3.2
+      # uses: arkon/issue-closer-action@v3.3
       uses: ./
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v1
+      with:
+        ref: 'add-blocklist-rule'
 
     - name: Autoclose issue
       # uses: arkon/issue-closer-action@v3.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
             {
               "type": "both",
               "regex":".*(mangago|mangafox|hq\\s*dragon|manga\\s*host).*",
-              "caseIgnore": true,
+              "ignoreCase": true,
               "message": "{match} will not be added back as it is too difficult to maintain"
             }
           ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
             },
             {
               "type": "both",
-              "regex":".*(mangago|mangafox|hq\s*dragon|manga\s*host).*",
+              "regex":".*(mangago|mangafox|hq\\s*dragon|manga\\s*host).*",
               "caseIgnore": true,
               "message": "{match} will not be added back as it is too difficult to maintain"
             }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Autoclose issues
-      uses: arkon/issue-closer-action@v3.2
+      uses: arkon/issue-closer-action@v3.3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         rules: |
@@ -44,12 +44,13 @@ jobs:
 
 ```js
 {
-  type: 'title' | 'body';
+  type: 'title' | 'body' | 'both';
   regex: string;
+  ignoreCase: boolean | undefined;
   message: string;
 }
 ```
 
 - `type`: Part to run regex against.
 - `regex`: String compiled to a JavaScript `Regexp`. If matched, the issue is closed.
-- `message`: ES2015-style template literal evaluated with the issue webhook payload in context (see [payload example](https://developer.github.com/v3/activity/events/types/#webhook-payload-example-15)). Posted when the issue is closed.
+- `message`: ES2015-style template literal evaluated with the issue webhook payload in context (see [payload example](https://developer.github.com/v3/activity/events/types/#webhook-payload-example-15)). Posted when the issue is closed. You can use `{match}` as a placeholder to the first match.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Autoclose issues
-      uses: arkon/issue-closer-action@v3.3
+      uses: arkon/issue-closer-action@v3.2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         rules: |

--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,11 @@ inputs:
       A JSON-compliant string containing a list of rules, where a rule consists of:
 
       {
-        type: 'title' | 'body';  // Part to run regex against.
-        regex: string;           // Pattern which if matched closes the issue.
-        message: string;         // Message to post when closing the issue.
+        type: 'title' | 'body';          // Part to run regex against.
+        regex: string;                   // Pattern which if matched closes the issue.
+        ignoreCase: boolean | undefined; // Defines if the regex will be case insensitive.
+        message: string;                 // Message to post when closing the issue.
+                                         // You can use {match} as a placeholder to the first match.
       }
 runs:
   using: node12

--- a/dist/index.js
+++ b/dist/index.js
@@ -337,7 +337,7 @@ function run() {
                 }
                 const regexMatches = check(rule.regex, texts, rule.ignoreCase);
                 const failed = regexMatches.length > 0;
-                const match = failed ? '<No match>' : regexMatches[0][1];
+                const match = failed ? regexMatches[0][1] : '<No match>';
                 const message = rule.message.replace(/\{match\}/g, match);
                 if (failed) {
                     core.info(`Failed: ${message}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -327,15 +327,24 @@ function run() {
             const parsedRules = JSON.parse(rules);
             const results = parsedRules
                 .map(rule => {
-                var _a, _b;
-                const text = rule.type === 'title' ? (_a = payload === null || payload === void 0 ? void 0 : payload.issue) === null || _a === void 0 ? void 0 : _a.title : (_b = payload === null || payload === void 0 ? void 0 : payload.issue) === null || _b === void 0 ? void 0 : _b.body;
-                const regexMatches = check(rule.regex, text);
-                if (regexMatches) {
-                    core.info(`Failed: ${rule.message}`);
-                    return rule.message;
+                var _a, _b, _c;
+                let texts = [(_a = payload === null || payload === void 0 ? void 0 : payload.issue) === null || _a === void 0 ? void 0 : _a.title];
+                if (rule.type === 'body') {
+                    texts = [(_b = payload === null || payload === void 0 ? void 0 : payload.issue) === null || _b === void 0 ? void 0 : _b.body];
+                }
+                else if (rule.type === 'both') {
+                    texts.push((_c = payload === null || payload === void 0 ? void 0 : payload.issue) === null || _c === void 0 ? void 0 : _c.body);
+                }
+                const regexMatches = check(rule.regex, texts, rule.ignoreCase);
+                const failed = regexMatches.length > 0;
+                const match = failed ? '<No match>' : regexMatches[0][1];
+                const message = rule.message.replace(/\{match\}/g, match);
+                if (failed) {
+                    core.info(`Failed: ${message}`);
+                    return message;
                 }
                 else {
-                    core.info(`Passed: ${rule.message}`);
+                    core.info(`Passed: ${message}`);
                 }
             })
                 .filter(Boolean);
@@ -371,9 +380,15 @@ function run() {
         }
     });
 }
-function check(patternString, text) {
-    const pattern = new RegExp(patternString);
-    return (text === null || text === void 0 ? void 0 : text.match(pattern)) !== null;
+function check(patternString, texts, ignoreCase = false) {
+    var _a;
+    const pattern = new RegExp(patternString, ignoreCase ? 'i' : undefined);
+    return (_a = texts === null || texts === void 0 ? void 0 : texts.map(text => {
+        return text
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .match(pattern);
+    })) === null || _a === void 0 ? void 0 : _a.filter(Boolean);
 }
 function evalTemplate(template, params) {
     return Function(...Object.keys(params), `return \`${template}\``)(...Object.values(params));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arkon/issue-closer",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "GitHub action to automatically close issues based on regexs matching",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arkon/issue-closer",
-  "version": "3.3.0",
+  "version": "3.2.0",
   "description": "GitHub action to automatically close issues based on regexs matching",
   "license": "MIT",
   "repository": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -99,10 +99,22 @@ async function run() {
   }
 }
 
+/**
+ * Checks all the texts in an array through an RegEx pattern 
+ * and returns the match results of the ones that matched.
+ * 
+ * @param patternString The RegEx input in string format that will be created.
+ * @param texts The text array that will be tested through the pattern.
+ * @param ignoreCase If it should be case insensitive.
+ * @returns An array of the RegEx match results.
+ */
 function check(patternString: string, texts: string[] | undefined, ignoreCase: boolean = false): Array<RegExpMatchArray> {
   const pattern = new RegExp(patternString, ignoreCase ? 'i' : undefined);
   return texts
     ?.map(text => {
+      // For all the texts (title or body), the input will be
+      // normalized to remove any accents or diacritics, and then
+      // will be tested by the pattern provided.
       return text
         .normalize('NFD')
         .replace(/[\u0300-\u036f]/g, '')

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import * as github from '@actions/github';
 interface Rule {
   type: 'title' | 'body' | 'both';
   regex: string;
-  caseIgnore?: boolean;
+  ignoreCase?: boolean;
   message: string;
 }
 
@@ -32,7 +32,7 @@ async function run() {
     const parsedRules = JSON.parse(rules) as Rule[];
     const results = parsedRules
       .map(rule => {
-        let texts: Array<string> = [payload?.issue?.title];
+        let texts: string[] = [payload?.issue?.title];
 
         if (rule.type === 'body') {
           texts = [payload?.issue?.body];
@@ -40,10 +40,10 @@ async function run() {
           texts.push(payload?.issue?.body)
         }
 
-        const regexMatches = check(rule.regex, texts, rule.caseIgnore || false);
+        const regexMatches = check(rule.regex, texts, rule.ignoreCase);
         const failed = regexMatches.length > 0;
         const match = failed ? '<No match>' : regexMatches[0][1];
-        const message = rule.message.replace(/\{match\}/g, match)
+        const message = rule.message.replace(/\{match\}/g, match);
 
         if (failed) {
           core.info(`Failed: ${message}`);
@@ -99,8 +99,8 @@ async function run() {
   }
 }
 
-function check(patternString: string, texts: Array<string> | undefined, caseIgnore: boolean = false): Array<RegExpMatchArray> {
-  const pattern = new RegExp(patternString);
+function check(patternString: string, texts: string[] | undefined, ignoreCase: boolean = false): Array<RegExpMatchArray> {
+  const pattern = new RegExp(patternString, ignoreCase ? 'i' : undefined);
   return texts
     ?.map(text => {
       return text

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,7 +104,7 @@ function check(patternString: string, texts: Array<string> | undefined, caseIgno
   return texts
     ?.map(text => {
       return text
-        .normalize("NFD")
+        .normalize('NFD')
         .replace(/[\u0300-\u036f]/g, '')
         .match(pattern);
     })

--- a/src/main.ts
+++ b/src/main.ts
@@ -102,7 +102,12 @@ async function run() {
 function check(patternString: string, texts: Array<string> | undefined, caseIgnore: boolean = false): Array<RegExpMatchArray> {
   const pattern = new RegExp(patternString);
   return texts
-    ?.map(text => text.match(pattern))
+    ?.map(text => {
+      return text
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, '')
+        .match(pattern);
+    })
     ?.filter(Boolean);
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,7 @@ async function run() {
 
         const regexMatches = check(rule.regex, texts, rule.ignoreCase);
         const failed = regexMatches.length > 0;
-        const match = failed ? '<No match>' : regexMatches[0][1];
+        const match = failed ? regexMatches[0][1] : '<No match>';
         const message = rule.message.replace(/\{match\}/g, match);
 
         if (failed) {


### PR DESCRIPTION
Should now accept rules like this (in theory):

```json
{
  "type": "both",
  "regex":".*(mangago|mangafox).*",
  "caseIgnore": true,
  "message": "{match} will not be added back as it is too difficult to maintain"
}
```

I did not bump the version in package now because it was not tested.